### PR TITLE
test build 1 thread

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/bld
       shell: bash
-      run: make -j 2
+      run: make -j 1
 
     - name: Build rpms
       working-directory: ${{github.workspace}}/bld


### PR DESCRIPTION
Building with ``make -j2`` sometimes fails (Out of memory ?), but with ``make -j1`` it finishes stable